### PR TITLE
move bsBounceStudio_init() code to PHP_MINIT_FUNCTION to prevent mult…

### DIFF
--- a/src/php_bouncestudio.c
+++ b/src/php_bouncestudio.c
@@ -16,9 +16,6 @@ PHP_METHOD(BounceStudio, __construct)
         return;
     }
 
-    // init bounce studio
-    bsBounceStudio_init();
-
     // set the properties
     zval *self = getThis();
     zend_update_property_string(bouncestudio_ce, self, "license", sizeof("license") - 1, license->val);
@@ -402,6 +399,9 @@ PHP_MINIT_FUNCTION(bouncestudio)
 
     zend_declare_property_long(bouncestudio_ce, "code", sizeof("code")-1, 0, ZEND_ACC_PRIVATE);
     zend_declare_property_string(bouncestudio_ce, "email", sizeof("email")-1, "", ZEND_ACC_PRIVATE);
+
+    // init bounce studio
+    bsBounceStudio_init();
 
     return SUCCESS;
 }


### PR DESCRIPTION
Hi Mizmoz,

I'm sorry for the long introduction below, so please, bear with me :)

I stumbled upon your codebase while I was trying to resolve an issue we have with our own implementation of a ported version of the php7 module for BounceStudio.

We went through the same process of creating a php7 module for BounceStudio, a couple of months ago. Since there was no support for php7, we decided to port the code, based on the current php5 implementation.

Recently we moved the application to AWS, where we have better monitoring of memory usage. So, since a few weeks we noticed serious memory leaks and we pinpointed them to our integration of the php7 module.

It turns out that calling the bsBounceStudio_init(); in the constructor method, allocates and re-allocated memory over and over again, every time a new instance of the class is created.

When running the code in a single script (e.g. from the command line), this is not a big deal, but when you load the code through a webserver like apache, then every time you instantiate a class, additional memory gets allocated. So after a few calls, the server runs out of memory.

We moved the function over to the PHP_MINIT_FUNCTION (since that gets called when the module is included for the first time), and first tests indicate that it keeps on working as expected, but the memory footprint is a lot better.

Since your code does the same as ours, I noticed that you also call  bsBounceStudio_init() from within the constructor.

Also, since your implementation does a better job on overall memory management then ours, we would like to use your implementation in our project.

Therefor, I would kindly like to ask you to accept this pull request.

If you have any further questions or remarks, do not hesitate to ping me!

Kind regards,

Stijn
